### PR TITLE
add support for moving seeds between entities

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -2,5 +2,6 @@
 !.git/
 !*.json
 !yarn.lock
+!.yarnrc
 !src/
 !nginx/

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,11 +6,12 @@ ARG VERSION
 
 RUN apk add --update --no-cache git
 
-COPY package.json yarn.lock /usr/src/app/
+COPY package.json yarn.lock .yarnrc /usr/src/app/
 WORKDIR /usr/src/app
-RUN yarn install && yarn cache clean
+RUN yarn
 
 COPY . .
+
 RUN VERSION=${VERSION:-$(git describe --tags --always)} \
 && sed -i "s/version: ''/version: '${VERSION}'/" src/environments/*.ts \
 && node_modules/@angular/cli/bin/ng build --configuration=production

--- a/src/modules/commons/commons.module.ts
+++ b/src/modules/commons/commons.module.ts
@@ -15,6 +15,7 @@ import {
   ToolbarComponent
 } from './components';
 import {DragDropModule} from '@angular/cdk/drag-drop';
+import {SeedMetaComponent} from './components/seed-meta/seed-meta.component';
 
 
 @NgModule({
@@ -22,6 +23,7 @@ import {DragDropModule} from '@angular/cdk/drag-drop';
     ToolbarComponent,
     LabelsComponent,
     MetaComponent,
+    SeedMetaComponent,
     BaseListComponent,
     EntityDetailsComponent,
     EntityDetailsMultiComponent,

--- a/src/modules/commons/commons.module.ts
+++ b/src/modules/commons/commons.module.ts
@@ -14,6 +14,7 @@ import {
   SeedDetailMultiComponent,
   ToolbarComponent
 } from './components';
+import {DragDropModule} from '@angular/cdk/drag-drop';
 
 
 @NgModule({
@@ -38,6 +39,7 @@ import {
     FormsModule,
     ReactiveFormsModule,
     RouterModule,
+    DragDropModule,
   ],
   exports: [
     ToolbarComponent,

--- a/src/modules/commons/components/meta/meta.component.css
+++ b/src/modules/commons/components/meta/meta.component.css
@@ -1,3 +1,0 @@
-.mat-chip-error {
-  color: #f44336;
-}

--- a/src/modules/commons/components/meta/meta.component.html
+++ b/src/modules/commons/components/meta/meta.component.html
@@ -1,6 +1,6 @@
 <div [formGroup]="form" fxLayout="column">
 
-  <mat-form-field *ngIf="!nameIsUrl; else url" [hideRequiredMarker]="nameInput.value.length >= 2">
+  <mat-form-field [hideRequiredMarker]="nameInput.value.length >= 2">
     <input matInput #nameInput formControlName="name" placeholder="Navn"
            i18n-placeholder="@@metaNameInputPlaceholder" required>
     <mat-hint *ngIf="nameInput.value.length < 2">Minimum 2 tegn</mat-hint>
@@ -9,46 +9,6 @@
       Navn er påkrevd
     </mat-error>
   </mat-form-field>
-
-
-  <!-- Multi url input, only available when creating new seed -->
-  <ng-template #url>
-    <mat-form-field *ngIf="id === ''">
-    <textarea matInput formControlName="name" placeholder="URL"
-              i18n="@@metaUrlInputPlaceholder"
-              cdkTextareaAutosize
-              cdkAutosizeMinRows="2"
-              cdkAutosizeMaxRows="10"
-              #autosize="cdkTextareaAutosize">
-    </textarea>
-      <mat-error
-        *ngIf="name.hasError('required') && name.dirty"
-        i18n="@@metaUrlRequiredError">
-        En gyldig URL er påkrevd
-      </mat-error>
-      <mat-error *ngIf="name.hasError('pattern') && !name.hasError('required')">
-        Inneholder ikke en gyldig formatert url
-      </mat-error>
-      <mat-error *ngIf="name.hasError('seedExists') && !name.hasError('required')">
-        Url(er) finnes fra før
-      </mat-error>
-    </mat-form-field>
-
-    <!-- Seed url input, when updating existing seed -->
-
-    <mat-form-field *ngIf="id !== ''">
-      <input matInput formControlName="name" placeholder="URL"
-             i18n="@@metaUrlInputPlaceholder">
-      <mat-error
-        *ngIf="name.hasError('required') && name.dirty"
-        i18n="@@metaUrlRequiredError">
-        En gyldig URL er påkrevd
-      </mat-error>
-      <mat-error *ngIf="name.hasError('pattern') && !name.hasError('required')">
-        Inneholder ikke en gyldig formatert url
-      </mat-error>
-    </mat-form-field>
-  </ng-template>
 
   <mat-form-field>
     <textarea matInput formControlName="description" placeholder="Beskrivelse"

--- a/src/modules/commons/components/meta/meta.component.html
+++ b/src/modules/commons/components/meta/meta.component.html
@@ -1,6 +1,6 @@
 <div [formGroup]="form" fxLayout="column">
 
-  <mat-form-field *ngIf="!nameIsUrl" [hideRequiredMarker]="nameInput.value.length >= 2">
+  <mat-form-field *ngIf="!nameIsUrl; else url" [hideRequiredMarker]="nameInput.value.length >= 2">
     <input matInput #nameInput formControlName="name" placeholder="Navn"
            i18n-placeholder="@@metaNameInputPlaceholder" required>
     <mat-hint *ngIf="nameInput.value.length < 2">Minimum 2 tegn</mat-hint>
@@ -12,7 +12,7 @@
 
 
   <!-- Multi url input, only available when creating new seed -->
-  <ng-container *ngIf="nameIsUrl">
+  <ng-template #url>
     <mat-form-field *ngIf="id === ''">
     <textarea matInput formControlName="name" placeholder="URL"
               i18n="@@metaUrlInputPlaceholder"
@@ -21,7 +21,6 @@
               cdkAutosizeMaxRows="10"
               #autosize="cdkTextareaAutosize">
     </textarea>
-
       <mat-error
         *ngIf="name.hasError('required') && name.dirty"
         i18n="@@metaUrlRequiredError">
@@ -30,26 +29,10 @@
       <mat-error *ngIf="name.hasError('pattern') && !name.hasError('required')">
         Inneholder ikke en gyldig formatert url
       </mat-error>
-    </mat-form-field>
-    <ng-container *ngIf="id === ''">
-      <mat-error *ngIf="name.hasError('seedExists')">
-        Url(er) er allerede i bruk
-        <mat-chip-list #chipList fxLayout="row wrap" fxLayoutGap="8px" style="margin-top: 1em; margin-bottom: 1em;">
-          <mat-chip class="mat-chip-error"
-                    *ngFor="let seed of name.errors.seedExists"
-                    (removed)="onRemoveExistingUrl(seed.uri)">
-            <a class="mat-chip-error"
-               target="_blank"
-               matTooltip="Gå til entiten som allerede har en seed med denne nettadressen"
-               [routerLink]="['../search']"
-               [queryParams]="{id: seed.entity}">
-              {{seed.uri}}
-            </a>
-            <mat-icon matTooltip="Fjern url fra listen" matChipRemove>cancel</mat-icon>
-          </mat-chip>
-        </mat-chip-list>
+      <mat-error *ngIf="name.hasError('seedExists') && !name.hasError('required')">
+        Url(er) finnes fra før
       </mat-error>
-    </ng-container>
+    </mat-form-field>
 
     <!-- Seed url input, when updating existing seed -->
 
@@ -61,28 +44,11 @@
         i18n="@@metaUrlRequiredError">
         En gyldig URL er påkrevd
       </mat-error>
-      <mat-error *ngIf="name.hasError('seedExists')">
-
-        Url(er) er allerede i bruk
-        <ul>
-          <li *ngFor="let exists of name.errors.seedExists">
-            <a class="seed-exists-link "
-               target="_blank"
-               [routerLink]="['../search']"
-               [queryParams]="{id: exists.entity}">
-              {{exists.uri}}
-            </a>
-            <button mat-icon-button (click)="onRemoveExistingUrl(exists.uri)">
-              <mat-icon>close</mat-icon>
-            </button>
-          </li>
-        </ul>
-      </mat-error>
       <mat-error *ngIf="name.hasError('pattern') && !name.hasError('required')">
         Inneholder ikke en gyldig formatert url
       </mat-error>
     </mat-form-field>
-  </ng-container>
+  </ng-template>
 
   <mat-form-field>
     <textarea matInput formControlName="description" placeholder="Beskrivelse"

--- a/src/modules/commons/components/seed-meta/seed-meta.component.css
+++ b/src/modules/commons/components/seed-meta/seed-meta.component.css
@@ -1,0 +1,3 @@
+.mat-chip-error {
+  color: #f44336;
+}

--- a/src/modules/commons/components/seed-meta/seed-meta.component.html
+++ b/src/modules/commons/components/seed-meta/seed-meta.component.html
@@ -1,0 +1,94 @@
+<div [formGroup]="form" fxLayout="column">
+  <mat-form-field>
+    <textarea matInput formControlName="name" placeholder="URL"
+              *ngIf="!created.value"
+              i18n="@@metaUrlInputPlaceholder"
+              cdkTextareaAutosize
+              cdkAutosizeMinRows="2"
+              cdkAutosizeMaxRows="10"
+              #autosize="cdkTextareaAutosize">
+    </textarea>
+
+    <input matInput formControlName="name" placeholder="URL"
+           *ngIf="created.value"
+           i18n="@@metaUrlInputPlaceholder">
+
+    <mat-error
+      *ngIf="name.hasError('required') && name.dirty"
+      i18n="@@metaUrlRequiredError">
+      Feltet må fylles ut
+    </mat-error>
+
+    <mat-error *ngIf="name.hasError('pattern') && !name.hasError('required')">
+      Inneholder en ugyldig formatert url
+    </mat-error>
+  </mat-form-field>
+
+  <mat-list *ngIf="name.hasError('seedExists')">
+    <mat-list-item>
+      <mat-error>
+        Andre entiteter inneholder seed med samme url som er skrevet inn
+      </mat-error>
+    </mat-list-item>
+    <mat-list-item *ngFor="let seed of name.errors.seedExists">
+
+      <a target="_blank"
+         matTooltip="Gå til entiten som allerede har en seed med lik url"
+         [routerLink]="['../search']"
+         [queryParams]="{id: seed.seed.entityRef.id}">
+        {{seed.meta.name}}
+      </a>
+
+      <button mat-icon-button
+              (click)="onMoveSeedToCurrentEntity(seed)"
+              matTooltip="Flytt seed til denne entiteten">
+        <mat-icon mat-list-icon>merge_type</mat-icon>
+      </button>
+
+      <button mat-icon-button (click)="onRemoveExistingUrl(seed.meta.name)"
+              matTooltip="Fjern url fra listen">
+        <mat-icon mat-list-icon>cancel</mat-icon>
+      </button>
+    </mat-list-item>
+  </mat-list>
+
+  <mat-form-field>
+    <textarea matInput formControlName="description" placeholder="Beskrivelse"
+              i18n-placeholder="@@metaDescriptionInputPlaceholder" matTextareaAutosize>
+    </textarea>
+  </mat-form-field>
+
+  <app-labels [removable]="editable" formControlName="labelList"></app-labels>
+
+  <div fxLayout="row" fxLayout.xs="column" fxLayoutGap="8px">
+    <mat-form-field fxFlex *ngIf="created.value">
+      <input matInput
+             formControlName="created"
+             placeholder="Opprettet"
+             i18n-placeholder="@@metaCreatedInputPlaceholder">
+    </mat-form-field>
+
+    <mat-form-field fxFlex *ngIf="createdBy.value">
+      <input matInput
+             formControlName="createdBy"
+             placeholder="Opprettet av"
+             i18n-placeholder="@@metaCreatedByInputPlaceholder">
+    </mat-form-field>
+  </div>
+
+  <div fxLayout="row" fxLayout.xs="column" fxLayoutGap="8px">
+    <mat-form-field fxFlex *ngIf="lastModified.value">
+      <input matInput
+             formControlName=lastModified
+             placeholder="Sist endret"
+             i18n-placeholder="@@metaLastModifiedInputPlaceholder">
+    </mat-form-field>
+
+    <mat-form-field fxFlex *ngIf="lastModifiedBy.value">
+      <input matInput
+             formControlName="lastModifiedBy"
+             placeholder="Sist endret av"
+             i18n-placeholder="@@metaLastModifiedByInputPlaceholder">
+    </mat-form-field>
+  </div>
+</div>

--- a/src/modules/commons/components/seed-meta/seed-meta.component.spec.ts
+++ b/src/modules/commons/components/seed-meta/seed-meta.component.spec.ts
@@ -1,0 +1,25 @@
+import {async, ComponentFixture, TestBed} from '@angular/core/testing';
+
+import {SeedMetaComponent} from './seed-meta.component';
+
+describe('SeedMetaComponent', () => {
+  let component: SeedMetaComponent;
+  let fixture: ComponentFixture<SeedMetaComponent>;
+
+  beforeEach(async(() => {
+    TestBed.configureTestingModule({
+      declarations: [SeedMetaComponent]
+    })
+      .compileComponents();
+  }));
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(SeedMetaComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/modules/commons/components/seed-meta/seed-meta.component.ts
+++ b/src/modules/commons/components/seed-meta/seed-meta.component.ts
@@ -1,0 +1,101 @@
+import {ChangeDetectionStrategy, ChangeDetectorRef, Component, EventEmitter, forwardRef, Input, Output, ViewChild} from '@angular/core';
+
+import {DatePipe} from '@angular/common';
+import {
+  AbstractControl,
+  AsyncValidator,
+  FormBuilder,
+  NG_ASYNC_VALIDATORS,
+  NG_VALUE_ACCESSOR,
+  ValidationErrors,
+  Validators
+} from '@angular/forms';
+import {CdkTextareaAutosize} from '@angular/cdk/text-field';
+import {SeedUrlValidator} from '../../validator/existing-url-validation';
+import {MetaComponent} from '../meta/meta.component';
+import {BackendService} from '../../../core/services';
+import {Observable, of} from 'rxjs';
+import {map, take, tap} from 'rxjs/operators';
+import {VALID_URL} from '../../validator/patterns';
+import {ConfigObject, ConfigRef, Meta} from '../../models';
+
+
+@Component({
+  selector: 'app-seed-meta',
+  templateUrl: './seed-meta.component.html',
+  styleUrls: ['./seed-meta.component.css'],
+  providers: [
+    {provide: NG_VALUE_ACCESSOR, useExisting: forwardRef(() => SeedMetaComponent), multi: true},
+    {provide: NG_ASYNC_VALIDATORS, useExisting: forwardRef(() => SeedMetaComponent), multi: true}
+  ],
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class SeedMetaComponent extends MetaComponent implements AsyncValidator {
+
+  @Input()
+  entityRef: ConfigRef;
+
+  @Output()
+  move = new EventEmitter<ConfigObject>();
+
+  @ViewChild('autosize')
+  txtAreaAutosize: CdkTextareaAutosize;
+
+  constructor(protected fb: FormBuilder,
+              protected datePipe: DatePipe,
+              private cdr: ChangeDetectorRef,
+              private backendService: BackendService) {
+    super(fb, datePipe);
+  }
+
+  protected createForm(): void {
+    super.createForm();
+    this.name.setValidators(Validators.compose([this.name.validator, Validators.pattern(VALID_URL)]));
+  }
+
+  protected updateForm(meta: Meta): void {
+    if (meta.created) {
+      this.name.clearAsyncValidators();
+    } else {
+      this.name.setAsyncValidators(SeedUrlValidator.createValidator(this.backendService));
+    }
+    super.updateForm(meta);
+  }
+
+  onRemoveExistingUrl(url: string) {
+    const urls: string = this.name.value;
+    const replaced = urls.replace(url, '').trim();
+    this.name.setValue(replaced);
+  }
+
+  onMoveSeedToCurrentEntity(seed: any) {
+    this.onRemoveExistingUrl(seed.meta.name);
+    this.move.emit(seed);
+  }
+
+  validate(control: AbstractControl): Promise<ValidationErrors | null> | Observable<ValidationErrors | null> {
+    if (!this.name.pending) {
+      return this.name.valid ? of(null) : of(this.name.errors);
+    } else {
+      return this.name.statusChanges.pipe(
+        tap(state => {
+          if (state === 'INVALID') {
+            this.checkSeedExistsWithSameEntity(this.name.errors.seedExists);
+          }
+        }),
+        map(state => state === 'VALID' ? null : this.name.errors),
+        tap(() => this.cdr.markForCheck()),
+        take(1)
+      );
+    }
+  }
+
+  private checkSeedExistsWithSameEntity(seeds) {
+    for (const seed of seeds) {
+      const seedEntityId = seed.seed.entityRef.id;
+      if (seedEntityId === this.entityRef.id && !this.created.value) {
+        Promise.resolve().then(() => this.onRemoveExistingUrl(seed.meta.name));
+      }
+    }
+  }
+}

--- a/src/modules/commons/components/seeds/seed-details/seed-details.component.css
+++ b/src/modules/commons/components/seeds/seed-details/seed-details.component.css
@@ -1,1 +1,4 @@
+.mat-chip-error {
+  color: #f44336;
+}
 

--- a/src/modules/commons/components/seeds/seed-details/seed-details.component.css
+++ b/src/modules/commons/components/seeds/seed-details/seed-details.component.css
@@ -1,4 +1,0 @@
-.mat-chip-error {
-  color: #f44336;
-}
-

--- a/src/modules/commons/components/seeds/seed-details/seed-details.component.html
+++ b/src/modules/commons/components/seeds/seed-details/seed-details.component.html
@@ -22,9 +22,11 @@
       </div>
     </mat-card-header>
     <mat-card-content fxLayout="row wrap" fxLayoutGap="24px">
-
       <div fxFlex fxLayout="column">
-        <app-meta formControlName="meta" [nameIsUrl]="true" [id]="configObject.id"></app-meta>
+        <app-meta formControlName="meta"
+                  [nameIsUrl]="true"
+                  [id]="configObject.id">
+        </app-meta>
         <mat-form-field *ngIf="configObject.id">
           <input matInput
                  formControlName="id"
@@ -49,6 +51,32 @@
                         [value]="crawlJob.id">{{crawlJob.meta.name}}</mat-option>
           </mat-select>
         </mat-form-field>
+
+        <ng-container *ngIf="meta.errors?.name?.seedExists">
+          <mat-error>
+            Andre entiteter inneholder seed med samme url som er skrevet inn
+          </mat-error>
+            <mat-chip-list fxLayout="row wrap"
+                           fxLayoutGap="8px">
+              <mat-chip class="mat-chip-error"
+                        *ngFor="let seed of meta.errors.name.seedExists"
+                        (removed)="onRemoveExistingUrl(seed.meta.name)">
+                <button mat-icon-button>
+                  <mat-icon matTooltip="Flytt seed til denne entiteten"
+                            (click)="onMoveSeedToCurrentEntity(seed)">arrow_back
+                  </mat-icon>
+                </button>
+                <a class="mat-chip-error"
+                   target="_blank"
+                   matTooltip="Gå til entiten som allerede har en seed med lik url"
+                   [routerLink]="['../search']"
+                   [queryParams]="{id: seed.seed.entityRef.id}">
+                  {{seed.meta.name}}
+                </a>
+                <mat-icon matTooltip="Fjern url fra listen" matChipRemove>cancel</mat-icon>
+              </mat-chip>
+            </mat-chip-list>
+        </ng-container>
 
         <mat-form-field formGroupName="scope" *ngIf="configObject?.id">
           <input matInput

--- a/src/modules/commons/components/seeds/seed-details/seed-details.component.html
+++ b/src/modules/commons/components/seeds/seed-details/seed-details.component.html
@@ -23,10 +23,9 @@
     </mat-card-header>
     <mat-card-content fxLayout="row wrap" fxLayoutGap="24px">
       <div fxFlex fxLayout="column">
-        <app-meta formControlName="meta"
-                  [nameIsUrl]="true"
-                  [id]="configObject.id">
-        </app-meta>
+        <app-seed-meta formControlName="meta"
+                       (move)="move.emit($event)"
+                       [entityRef]="configObject.seed.entityRef"></app-seed-meta>
         <mat-form-field *ngIf="configObject.id">
           <input matInput
                  formControlName="id"
@@ -34,14 +33,14 @@
                  readonly
                  i18n-placeholder="@@seedFormIdPlaceholder">
         </mat-form-field>
-        <ng-container formGroupName="entityRef">
-          <mat-form-field *ngIf="configObject?.id">
-            <input matInput formControlName="id"
-                   placeholder="Entitetens Id"
-                   readonly
-                   i18n-placeholder="@@metaEntityIdInputPlaceholder">
-          </mat-form-field>
-        </ng-container>
+
+        <mat-form-field formGroupName="entityRef"
+                        *ngIf="configObject?.id">
+          <input matInput formControlName="id"
+                 placeholder="Entitetens Id"
+                 readonly
+                 i18n-placeholder="@@metaEntityIdInputPlaceholder">
+        </mat-form-field>
       </div>
 
       <div fxFlex fxLayout="column">
@@ -51,32 +50,6 @@
                         [value]="crawlJob.id">{{crawlJob.meta.name}}</mat-option>
           </mat-select>
         </mat-form-field>
-
-        <ng-container *ngIf="meta.errors?.name?.seedExists">
-          <mat-error>
-            Andre entiteter inneholder seed med samme url som er skrevet inn
-          </mat-error>
-            <mat-chip-list fxLayout="row wrap"
-                           fxLayoutGap="8px">
-              <mat-chip class="mat-chip-error"
-                        *ngFor="let seed of meta.errors.name.seedExists"
-                        (removed)="onRemoveExistingUrl(seed.meta.name)">
-                <button mat-icon-button>
-                  <mat-icon matTooltip="Flytt seed til denne entiteten"
-                            (click)="onMoveSeedToCurrentEntity(seed)">arrow_back
-                  </mat-icon>
-                </button>
-                <a class="mat-chip-error"
-                   target="_blank"
-                   matTooltip="Gå til entiten som allerede har en seed med lik url"
-                   [routerLink]="['../search']"
-                   [queryParams]="{id: seed.seed.entityRef.id}">
-                  {{seed.meta.name}}
-                </a>
-                <mat-icon matTooltip="Fjern url fra listen" matChipRemove>cancel</mat-icon>
-              </mat-chip>
-            </mat-chip-list>
-        </ng-container>
 
         <mat-form-field formGroupName="scope" *ngIf="configObject?.id">
           <input matInput

--- a/src/modules/commons/components/seeds/seed-details/seed-details.component.ts
+++ b/src/modules/commons/components/seeds/seed-details/seed-details.component.ts
@@ -5,7 +5,6 @@ import {AbstractControl, FormBuilder, FormGroup} from '@angular/forms';
 import {AuthService} from '../../../../core/services/auth';
 import {ConfigObject, ConfigRef, Kind, Meta, Seed} from '../../../../commons/models';
 import {MetaComponent} from '../../meta/meta.component';
-import {filter} from 'rxjs/operators';
 
 @Component({
   selector: 'app-seed-details',
@@ -89,16 +88,16 @@ export class SeedDetailComponent implements OnChanges, OnInit {
   }
 
   ngOnInit(): void {
-     this.form.valueChanges.subscribe(() => {
-       if (this.form.dirty && this.form.status === 'INVALID' && this.meta.errors && this.meta.errors.name && this.meta.errors.name.seedExists) {
-         const existingSeeds = this.meta.errors.name.seedExists;
-         const entityId = this.configObject.seed.entityRef.id;
-          for (const seed of existingSeeds) {
-            const seedEntityRef = seed.seed.entityRef.id;
-            if (seedEntityRef === entityId && !this.configObject.id) {
-              this.onRemoveExistingUrl(seed.meta.name);
-            }
+    this.form.valueChanges.subscribe(() => {
+      if (this.form.dirty && this.form.status === 'INVALID' && this.meta.errors && this.meta.errors.name && this.meta.errors.name.seedExists) {
+        const existingSeeds = this.meta.errors.name.seedExists;
+        const entityId = this.configObject.seed.entityRef.id;
+        for (const seed of existingSeeds) {
+          const seedEntityRef = seed.seed.entityRef.id;
+          if (seedEntityRef === entityId && !this.configObject.id) {
+            this.onRemoveExistingUrl(seed.meta.name);
           }
+        }
       }
     });
   }

--- a/src/modules/commons/components/seeds/seed-details/seed-details.component.ts
+++ b/src/modules/commons/components/seeds/seed-details/seed-details.component.ts
@@ -150,12 +150,10 @@ export class SeedDetailComponent implements OnChanges, OnInit, OnDestroy {
   }
 
   onSave(): void {
-    if (this.isMultipleSeed() && this.form.valid) {
+    if (this.isMultipleSeed()) {
       this.saveMultiple.emit(this.prepareSaveMultiple());
     } else {
-      if (this.form.valid) {
-        this.save.emit(this.prepareSave());
-      }
+      this.save.emit(this.prepareSave());
     }
   }
 

--- a/src/modules/commons/components/seeds/seed-details/seed-details.component.ts
+++ b/src/modules/commons/components/seeds/seed-details/seed-details.component.ts
@@ -95,7 +95,7 @@ export class SeedDetailComponent implements OnChanges, OnInit {
          const entityId = this.configObject.seed.entityRef.id;
           for (const seed of existingSeeds) {
             const seedEntityRef = seed.seed.entityRef.id;
-            if (seedEntityRef === entityId) {
+            if (seedEntityRef === entityId && !this.configObject.id) {
               this.onRemoveExistingUrl(seed.meta.name);
             }
           }

--- a/src/modules/commons/models/configobject.model.ts
+++ b/src/modules/commons/models/configobject.model.ts
@@ -170,7 +170,7 @@ export class ConfigObject {
   static clone(configObject: ConfigObject): ConfigObject {
     const clone = new ConfigObject(configObject);
     clone.id = '';
-    clone.meta.name = clone.meta.name + ' (clone)';
+    Object.assign(clone.meta, {created: '', createdBy: '', lastModified: '', lastModifiedBy: '', name: ''});
     return clone;
   }
 

--- a/src/modules/commons/models/configobject.model.ts
+++ b/src/modules/commons/models/configobject.model.ts
@@ -13,6 +13,7 @@ import {CrawlHostGroupConfig} from './configs/crawlhostgroupconfig.model';
 import {RoleMapping} from './configs/rolemapping.model';
 import {Kind} from './kind.model';
 import {Meta} from './meta/meta.model';
+import {ConfigRef} from './configref.model';
 
 
 export class ConfigObject {
@@ -160,6 +161,10 @@ export class ConfigObject {
       proto.setCollection(Collection.toProto(configObject.collection));
     }
     return proto;
+  }
+
+  static toConfigRef(configObject: ConfigObject): ConfigRef {
+    return new ConfigRef({id: configObject.id, kind: configObject.kind});
   }
 
   static clone(configObject: ConfigObject): ConfigObject {

--- a/src/modules/commons/models/meta/meta.model.ts
+++ b/src/modules/commons/models/meta/meta.model.ts
@@ -1,6 +1,5 @@
 import {LabelProto, MetaProto} from '../../../../api';
 import {fromTimestampProto} from '../../func/datetime/datetime';
-import {ConfigObject} from '../configobject.model';
 import {Label} from './label.model';
 
 export class Meta {
@@ -15,14 +14,18 @@ export class Meta {
   constructor({
                 labelList,
                 description = '',
-                name = ''
+                name = '',
+                created = '',
+                createdBy = '',
+                lastModified = '',
+                lastModifiedBy = '',
               }: Partial<Meta> = {}) {
     this.name = name;
     this.description = description;
-    this.created = '';
-    this.createdBy = '';
-    this.lastModified = '';
-    this.lastModifiedBy = '';
+    this.created = created;
+    this.createdBy = createdBy;
+    this.lastModified = lastModified;
+    this.lastModifiedBy = lastModifiedBy;
     this.labelList = labelList ? labelList.map(label => new Label(label)) : [];
   }
 

--- a/src/modules/commons/validator/existing-url-validation.ts
+++ b/src/modules/commons/validator/existing-url-validation.ts
@@ -1,56 +1,42 @@
-import {AbstractControl, AsyncValidator, ValidationErrors} from '@angular/forms';
+import {AbstractControl, ValidationErrors} from '@angular/forms';
 import {from, Observable, of} from 'rxjs';
-import {catchError, map, mergeMap, tap, toArray} from 'rxjs/operators';
-import {Injectable} from '@angular/core';
+import {catchError, map, mergeMap, toArray} from 'rxjs/operators';
 import {ConfigObject, Kind} from '../models';
 import {BackendService} from '../../core/services';
 import {FieldMask, ListRequest} from '../../../api';
 
-@Injectable()
-export class SeedUrlValidator implements AsyncValidator {
+function seedWithMatchingUrl(url: string): ListRequest {
+  const request = new ListRequest();
+  const template = new ConfigObject({kind: Kind.SEED});
+  const mask = new FieldMask();
+
+  mask.setPathsList(['meta.name']);
+  template.meta.name = url;
+  request.setKind(Kind.SEED.valueOf());
+  request.setIdList([]);
+  request.setQueryMask(mask);
+  request.setQueryTemplate(ConfigObject.toProto(template));
+
+  return request;
+}
+
+export class SeedUrlValidator {
 
 
-  constructor(private backendService: BackendService) {
-  }
-
-  registerOnValidatorChange(fn: () => void): void {
-  }
-
-  validate(control: AbstractControl): Promise<ValidationErrors | null> | Observable<ValidationErrors | null>;
-  validate(control: AbstractControl): ValidationErrors | null;
-  validate(control: AbstractControl): Promise<ValidationErrors | null> | Observable<ValidationErrors | null> | ValidationErrors | null {
-
-    const urls: string = control.value.split(/\s+/).filter(u => !!u);
-
-    return from(urls).pipe(
-      mergeMap((url) => this.seedExists(url)),
-      toArray(),
-      map((seeds: ConfigObject[]) => seeds.length > 0 ? {seedExists: seeds} : null),
-      catchError((error) => {
-        console.error(error);
-        return of(null);
-      })
-    );
-  }
-
-
-  seedExists(seed: string): Observable<ConfigObject> {
-    const request = new ListRequest();
-    const template = new ConfigObject({kind: Kind.SEED});
-    const mask = new FieldMask();
-
-    mask.setPathsList(['meta.name']);
-    template.meta.name = seed;
-    request.setKind(Kind.SEED.valueOf());
-    request.setIdList([]);
-    request.setQueryMask(mask);
-    request.setQueryTemplate(ConfigObject.toProto(template));
-
-    return this.backendService.list(request)
-      .pipe(
-        map(configObject => ConfigObject.fromProto(configObject))
+  static createValidator(backendService: BackendService) {
+    return (control: AbstractControl): Observable<ValidationErrors | null> => {
+      const urls: string = control.value.split(/\s+/).filter(u => !!u);
+      return from(urls).pipe(
+        mergeMap((url) => backendService.list(seedWithMatchingUrl(url))),
+        map(configObject => ConfigObject.fromProto(configObject)),
+        toArray(),
+        map((seeds: ConfigObject[]) => seeds.length > 0 ? {seedExists: seeds} : null),
+        catchError((error) => {
+          console.error(error);
+          return of(null);
+        })
       );
+    };
   }
-
 }
 

--- a/src/modules/commons/validator/existing-url-validation.ts
+++ b/src/modules/commons/validator/existing-url-validation.ts
@@ -25,12 +25,7 @@ export class SeedUrlValidator implements AsyncValidator {
     return from(urls).pipe(
       mergeMap((url) => this.seedExists(url)),
       toArray(),
-      map((seed: ConfigObject[]) => seed.length > 0 ? {
-        seedExists: seed.map(s => ({
-          uri: s.meta.name,
-          entity: s.seed.entityRef.id
-        }))
-      } : null),
+      map((seeds: ConfigObject[]) => seeds.length > 0 ? {seedExists: seeds} : null),
       catchError((error) => {
         console.error(error);
         return of(null);

--- a/src/modules/configurations/containers/configurations/configurations.component.html
+++ b/src/modules/configurations/containers/configurations/configurations.component.html
@@ -6,7 +6,7 @@
   <mat-icon>add</mat-icon>
 </button>
 
-<button *ngIf="embedded"
+<button *ngIf="entityRef"
         mat-fab
         color="primary"
         class="action-button-secondary"
@@ -41,7 +41,7 @@
                  (selectedChange)="onSelectedChange($event)"
                  (selectAll)="onSelectAll()"
                  (clone)="onCreateConfig($event)"
-                 [embedded]="embedded"
+                 [embedded]="entityRef"
                  (page)="onPage($event)">
   </app-base-list>
 </ng-container>
@@ -118,6 +118,7 @@
                     (update)="onUpdateConfig($event)"
                     (save)="onSaveConfig($event)"
                     (saveMultiple)="onSaveMultipleSeeds($event)"
+                    (move)="onMove($event)"
                     (delete)="onDeleteConfig($event)">
   </app-seed-details>
 

--- a/src/modules/configurations/containers/search/search.component.html
+++ b/src/modules/configurations/containers/search/search.component.html
@@ -46,11 +46,11 @@
 
     <ng-template detail-host></ng-template>
   </div>
-  <ng-container *ngIf="configObject$ | async as configObject">
-    <app-configurations *ngIf="configObject?.id"
+  <ng-container *ngIf="configObject$ | async as entityObject">
+    <app-configurations *ngIf="entityObject?.id"
                         fxFlex
                         [kind]="Kind.SEED"
-                        [embedded]="true">
+                        [entityRef]="ConfigObject.toConfigRef(entityObject)">
     </app-configurations>
   </ng-container>
 </div>

--- a/src/modules/configurations/containers/search/search.component.ts
+++ b/src/modules/configurations/containers/search/search.component.ts
@@ -4,16 +4,14 @@ import {MatDialog} from '@angular/material';
 import {of, Subject} from 'rxjs';
 import {map, switchMap, takeUntil, tap} from 'rxjs/operators';
 
-import {Kind} from '../../../commons/models';
+import {ConfigObject, Kind} from '../../../commons/models';
 
 import {AuthService} from '../../../core/services/auth';
 import {ActivatedRoute, Router} from '@angular/router';
-import {SearchDataService} from '../../services';
+import {DataService, SearchDataService, SeedDataService} from '../../services';
 
 
 import {Title} from '@angular/platform-browser';
-import {SeedDataService} from '../../services';
-import {DataService} from '../../services';
 import {ConfigurationsComponent} from '../configurations/configurations.component';
 import {ErrorService, SnackBarService} from '../../../core/services';
 
@@ -27,6 +25,7 @@ import {ErrorService, SnackBarService} from '../../../core/services';
 })
 
 export class SearchComponent extends ConfigurationsComponent implements OnInit, OnDestroy {
+  readonly ConfigObject = ConfigObject;
 
   configObject$ = this.configObject.asObservable().pipe(
     tap(entity => {
@@ -47,10 +46,10 @@ export class SearchComponent extends ConfigurationsComponent implements OnInit, 
     protected componentFactoryResolver: ComponentFactoryResolver,
     protected router: Router,
     protected dialog: MatDialog,
-    protected dataService: SearchDataService,
+    protected searchDataService: SearchDataService,
     public titleService: Title,
     protected authService: AuthService) {
-    super(dataService, snackBarService, errorService, componentFactoryResolver, router, titleService, dialog, activatedRoute);
+    super(searchDataService, snackBarService, errorService, componentFactoryResolver, router, titleService, dialog, activatedRoute);
 
     this.kind = Kind.CRAWLENTITY;
   }
@@ -62,12 +61,12 @@ export class SearchComponent extends ConfigurationsComponent implements OnInit, 
   ngOnInit() {
     this.route.queryParamMap.pipe(
       map(queryParamMap => queryParamMap.get('id')),
-      switchMap(id => id ? this.dataService.get({id, kind: this.kind}) : of(null)),
+      switchMap(id => id ? this.searchDataService.get({id, kind: this.kind}) : of(null)),
       takeUntil(this.ngUnsubscribe)
     ).subscribe(configObject => this.configObject.next(configObject));
 
     this.searchTerm$.pipe(
-      switchMap((term: string) => this.dataService.search(term)),
+      switchMap((term: string) => this.searchDataService.search(term)),
       takeUntil(this.ngUnsubscribe)
     ).subscribe(() => {
     }, (error) => this.errorService.dispatch(error));

--- a/src/modules/configurations/services/data.service.ts
+++ b/src/modules/configurations/services/data.service.ts
@@ -126,6 +126,10 @@ export class DataService extends DataSource<ConfigObject> implements OnDestroy {
       );
   }
 
+  move(configObject: ConfigObject): Observable<number> {
+    return of(0);
+  }
+
   update(configObject): Observable<ConfigObject> {
     return this.backendService.save(ConfigObject.toProto(configObject))
       .pipe(
@@ -135,8 +139,7 @@ export class DataService extends DataSource<ConfigObject> implements OnDestroy {
   }
 
   updateWithTemplate(updateTemplate: ConfigObject, paths: string[], ids?: string[]): Observable<number> {
-    const listRequest = new ListRequest();
-    listRequest.setKind(updateTemplate.kind.valueOf());
+    const listRequest = ofKind(updateTemplate.kind.valueOf());
 
     if (ids && ids.length) {
       listRequest.setIdList(ids);
@@ -151,8 +154,7 @@ export class DataService extends DataSource<ConfigObject> implements OnDestroy {
     updateRequest.setUpdateMask(updateMask);
 
     return this.backendService.update(updateRequest).pipe(
-      map(updateResponse => updateResponse.getUpdated()),
-      tap(() => this.kind = this._kind)
+      map(updateResponse => updateResponse.getUpdated())
     );
   }
 

--- a/src/modules/event/containers/event-search/event-search.component.ts
+++ b/src/modules/event/containers/event-search/event-search.component.ts
@@ -54,7 +54,7 @@ export class EventSearchComponent extends SearchComponent implements OnInit {
 
     super(seedDataService, snackBarService, errorService, activatedRoute,
       componentFactoryResolver, router, dialog, dataService, titleService, authService);
-    this.embedded = true;
+    this.entityRef = true;
   }
 
   ngOnInit() {


### PR DESCRIPTION
When creating a new seed and the url is already in use by another seed, give the option to move the existing seed to the current entity