### PR TITLE
Add new baselist for use with seeds in entity/seeds view

### DIFF
--- a/src/modules/commons/commons.module.ts
+++ b/src/modules/commons/commons.module.ts
@@ -16,6 +16,7 @@ import {
 } from './components';
 import {DragDropModule} from '@angular/cdk/drag-drop';
 import {SeedMetaComponent} from './components/seed-meta/seed-meta.component';
+import { SeedBaseListComponent } from './components/seed-base-list/seed-base-list.component';
 
 
 @NgModule({
@@ -29,6 +30,7 @@ import {SeedMetaComponent} from './components/seed-meta/seed-meta.component';
     EntityDetailsMultiComponent,
     SeedDetailComponent,
     SeedDetailMultiComponent,
+    SeedBaseListComponent,
   ],
   entryComponents: [
     EntityDetailsMultiComponent,
@@ -48,6 +50,7 @@ import {SeedMetaComponent} from './components/seed-meta/seed-meta.component';
     LabelsComponent,
     MetaComponent,
     BaseListComponent,
+    SeedBaseListComponent,
     CommonModule,
     MaterialModule,
     FlexLayoutModule,

--- a/src/modules/commons/components/base-list/base-list.ts
+++ b/src/modules/commons/components/base-list/base-list.ts
@@ -10,9 +10,10 @@ import {
   Output,
   ViewChild
 } from '@angular/core';
-import { MatPaginator, PageEvent } from '@angular/material/paginator';
-import { MatTableDataSource } from '@angular/material/table';
+import {MatPaginator, PageEvent} from '@angular/material/paginator';
+import {MatTableDataSource} from '@angular/material/table';
 import {DataService} from '../../../configurations/services/data/data.service';
+import {MatSort} from '@angular/material';
 
 export enum Action {
   Clone = 'Clone'
@@ -58,7 +59,11 @@ export class BaseListComponent implements AfterViewInit {
   pageOptions = [5, 10, 25, 50, 100];
 
   @Input()
-  dataSource: (DataSource<any> & { data: any[], paginator?: MatPaginator, filteredData?: any[] }) | MatTableDataSource<any>;
+  dataSource: (DataSource<any> & {
+    data: any[], paginator?: MatPaginator,
+    filteredData?: any[], sort?: MatSort, filter?: string,
+    filterPredicate?: any, sortingDataAccessor?: any
+  }) | MatTableDataSource<any>;
 
   @Input()
   embedded = false;
@@ -78,11 +83,13 @@ export class BaseListComponent implements AfterViewInit {
   @Output()
   action: EventEmitter<ActionEvent> = new EventEmitter();
 
-  @ViewChild(MatPaginator, {static: false}) paginator;
+  @ViewChild(MatPaginator, {static: true}) paginator;
 
   constructor(protected cdr: ChangeDetectorRef,
               @Optional() dataSource: DataService) {
-    this.dataSource = dataSource;
+    if (!this.dataSource && dataSource) {
+      this.dataSource = dataSource;
+    }
   }
 
   get isAllInPageSelected(): boolean {

--- a/src/modules/commons/components/seed-base-list/seed-base-list.component.html
+++ b/src/modules/commons/components/seed-base-list/seed-base-list.component.html
@@ -1,0 +1,83 @@
+<div class="list-container__margin mat-elevation-z1">
+  <table class="mat-table" *ngIf="selection.selected.length > 1">
+    <tr class="mat-row">
+      <td class="mat-cell" *ngIf="!allSelected">
+        <span><strong>{{selection.selected.length}}</strong> konfigurasjoner er markert. </span>
+        <button mat-button *ngIf="!embedded && isAllInPageSelected" (click)="onSelectAll()">
+          MARKER ALLE KONFIGURASJONENE I DATABASEN
+        </button>
+      </td>
+      <td class="mat-cell" *ngIf="!embedded && allSelected">
+        <span>Alle <b>{{pageLength || ''}}</b> konfigurasjonene i databasen er markert. </span>
+        <button mat-button (click)="onDeselectAll()">FJERN MARKERINGEN</button>
+      </td>
+    </tr>
+  </table>
+
+  <mat-form-field class="seed-filter">
+    <input matInput #filter (keyup)="onFilterData(filter.value)" placeholder="Filter">
+  </mat-form-field>
+  <table mat-table [dataSource]="dataSource" matSort>
+    <ng-container matColumnDef="select">
+      <th mat-header-cell *matHeaderCellDef class="checkbox-padding">
+        <mat-checkbox #masterCheckbox
+                      (change)="onMasterCheckboxToggle(masterCheckbox.checked)"
+                      [checked]="selection.hasValue() && isAllInPageSelected"
+                      [indeterminate]="selection.hasValue() && !isAllInPageSelected">
+        </mat-checkbox>
+      </th>
+      <td mat-cell *matCellDef="let row" class="checkbox-padding">
+        <mat-checkbox [checked]="selection.isSelected(row)"
+                      (click)="$event.stopPropagation()"
+                      (change)="onCheckboxToggle(row)">
+        </mat-checkbox>
+      </td>
+    </ng-container>
+
+    <ng-container matColumnDef="name">
+      <th mat-header-cell *matHeaderCellDef mat-sort-header>URL</th>
+      <td mat-cell *matCellDef="let row">{{row.meta.name}}</td>
+    </ng-container>
+
+    <ng-container matColumnDef="description">
+      <th mat-header-cell *matHeaderCellDef>Beskrivelse</th>
+      <td mat-cell *matCellDef="let row">{{row.meta.description}}</td>
+    </ng-container>
+
+    <ng-container matColumnDef="id">
+      <th mat-header-cell *matHeaderCellDef>ID</th>
+      <td mat-cell *matCellDef="let row">{{row.id}}</td>
+    </ng-container>
+
+    <ng-container matColumnDef="action">
+      <th mat-header-cell *matHeaderCellDef></th>
+      <td mat-cell *matCellDef="let row" (click)="$event.stopPropagation()">
+        <button mat-icon-button [matMenuTriggerFor]="menu" aria-label="Action menu">
+          <mat-icon>more_vert</mat-icon>
+        </button>
+        <mat-menu #menu="matMenu">
+          <button mat-menu-item
+                  *ngFor="let action of actions"
+                  (click)="onAction(row, action.type)">
+            <mat-icon>{{ action.icon }}</mat-icon>
+            <span>{{ action.type }}</span>
+          </button>
+        </mat-menu>
+      </td>
+    </ng-container>
+
+    <tr mat-header-row *matHeaderRowDef="displayedColumns"></tr>
+    <tr mat-row *matRowDef="let row; columns: displayedColumns"
+        [ngClass]="isSelected(row) ? 'row-selected' : isChecked(row) ? 'row-checked': ''"
+        (click)="onRowClick(row)"></tr>
+  </table>
+
+  <mat-paginator
+    (page)="onPage($event)"
+    [ngClass]="pageLength ? 'hide-mat-paginator-range-label' : ''"
+    [length]="pageLength"
+    [pageIndex]="pageIndex"
+    [pageSize]="pageSize"
+    [pageSizeOptions]="pageOptions">
+  </mat-paginator>
+</div>

--- a/src/modules/commons/components/seed-base-list/seed-base-list.component.scss
+++ b/src/modules/commons/components/seed-base-list/seed-base-list.component.scss
@@ -1,0 +1,26 @@
+@import "../../../../styles/theme";
+
+table {
+  width: 100%;
+}
+
+.row-checked {
+  background-color: $light-focused;
+}
+
+.row-selected {
+  background-color: $dark-focused;
+}
+
+.mat-row:hover {
+  background-color: lighten($dark-focused, 50%);
+  cursor: pointer;
+}
+
+.checkbox-padding {
+  padding-right: 16px;
+}
+
+.seed-filter {
+  width: 100%;
+}

--- a/src/modules/commons/components/seed-base-list/seed-base-list.component.scss
+++ b/src/modules/commons/components/seed-base-list/seed-base-list.component.scss
@@ -1,26 +1,3 @@
-@import "../../../../styles/theme";
-
-table {
-  width: 100%;
-}
-
-.row-checked {
-  background-color: $light-focused;
-}
-
-.row-selected {
-  background-color: $dark-focused;
-}
-
-.mat-row:hover {
-  background-color: lighten($dark-focused, 50%);
-  cursor: pointer;
-}
-
-.checkbox-padding {
-  padding-right: 16px;
-}
-
 .seed-filter {
   width: 100%;
 }

--- a/src/modules/commons/components/seed-base-list/seed-base-list.component.spec.ts
+++ b/src/modules/commons/components/seed-base-list/seed-base-list.component.spec.ts
@@ -1,6 +1,10 @@
-import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+import {async, ComponentFixture, TestBed} from '@angular/core/testing';
 
-import { SeedBaseListComponent } from './seed-base-list.component';
+import {SeedBaseListComponent} from './seed-base-list.component';
+import {MaterialModule} from '../../material.module';
+import {NoopAnimationsModule} from '@angular/platform-browser/animations';
+import {DataService} from '../../../configurations/services/data';
+import {MatTableDataSource} from '@angular/material';
 
 describe('SeedBaseListComponent', () => {
   let component: SeedBaseListComponent;
@@ -8,9 +12,16 @@ describe('SeedBaseListComponent', () => {
 
   beforeEach(async(() => {
     TestBed.configureTestingModule({
-      declarations: [ SeedBaseListComponent ]
+      declarations: [SeedBaseListComponent],
+      imports: [MaterialModule, NoopAnimationsModule],
+      providers: [
+        {
+          provide: DataService,
+          useFactory: () => new MatTableDataSource([])
+        }
+      ]
     })
-    .compileComponents();
+      .compileComponents();
   }));
 
   beforeEach(() => {

--- a/src/modules/commons/components/seed-base-list/seed-base-list.component.spec.ts
+++ b/src/modules/commons/components/seed-base-list/seed-base-list.component.spec.ts
@@ -1,0 +1,25 @@
+import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { SeedBaseListComponent } from './seed-base-list.component';
+
+describe('SeedBaseListComponent', () => {
+  let component: SeedBaseListComponent;
+  let fixture: ComponentFixture<SeedBaseListComponent>;
+
+  beforeEach(async(() => {
+    TestBed.configureTestingModule({
+      declarations: [ SeedBaseListComponent ]
+    })
+    .compileComponents();
+  }));
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(SeedBaseListComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/modules/commons/components/seed-base-list/seed-base-list.component.ts
+++ b/src/modules/commons/components/seed-base-list/seed-base-list.component.ts
@@ -1,0 +1,50 @@
+import {AfterViewInit, ChangeDetectionStrategy, ChangeDetectorRef, Component, Optional, ViewChild} from '@angular/core';
+import {BaseListComponent} from '..';
+import {DataService} from '../../../configurations/services/data';
+import {MatSort} from '@angular/material';
+import {ConfigObject} from '../../models';
+import {_isNumberValue} from '@angular/cdk/coercion';
+
+@Component({
+  selector: 'app-seed-base-list',
+  templateUrl: './seed-base-list.component.html',
+  styleUrls: ['./seed-base-list.component.scss'],
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class SeedBaseListComponent extends BaseListComponent implements AfterViewInit {
+
+  @ViewChild(MatSort, {static: true}) sort: MatSort;
+
+  constructor(protected cdr: ChangeDetectorRef,
+              @Optional() dataSource: DataService) {
+    super(cdr, dataSource);
+  }
+
+  ngAfterViewInit() {
+    super.ngAfterViewInit();
+
+    this.dataSource.filterPredicate = (data: ConfigObject, filter: string) => {
+      // Transform the data into a lowercase string of all property values.
+      const accumulator = (currentTerm, key) => currentTerm + data.meta[key];
+
+      // filter on name
+      const dataStr = ['name'].reduce(accumulator, '').toLowerCase();
+
+      // Transform the filter by converting it to lowercase and removing whitespace.
+      const transformedFilter = filter.trim().toLowerCase();
+
+      return dataStr.indexOf(transformedFilter) !== -1;
+    };
+
+    this.dataSource.sortingDataAccessor = (data: ConfigObject, sortHeaderId: string): string | number => {
+      const value: any = data.meta[sortHeaderId];
+      return _isNumberValue(value) ? Number(value) : value;
+    };
+
+    this.dataSource.sort = this.sort;
+  }
+
+  onFilterData(filterValue: string) {
+    this.dataSource.filter = filterValue.trim().toLowerCase();
+  }
+}

--- a/src/modules/commons/components/seed-base-list/seed-base-list.component.ts
+++ b/src/modules/commons/components/seed-base-list/seed-base-list.component.ts
@@ -8,7 +8,7 @@ import {_isNumberValue} from '@angular/cdk/coercion';
 @Component({
   selector: 'app-seed-base-list',
   templateUrl: './seed-base-list.component.html',
-  styleUrls: ['./seed-base-list.component.scss'],
+  styleUrls: ['../base-list/base-list.scss', './seed-base-list.component.scss'],
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class SeedBaseListComponent extends BaseListComponent implements AfterViewInit {

--- a/src/modules/commons/components/seed-meta/seed-meta.component.ts
+++ b/src/modules/commons/components/seed-meta/seed-meta.component.ts
@@ -77,7 +77,9 @@ export class SeedMetaComponent extends MetaComponent implements AsyncValidator {
   }
 
   onRemoveExistingUrls(urls: string[]) {
-    const replaced = urls.reduce((acc, url) => acc.replace(url, '').trim(), this.name.value);
+    const replaced = urls.reduce((acc, url) => acc.replace(url, '')
+      .trim()
+      .replace(/\s{2,}/, ' \n'), this.name.value);
     this.name.setValue(replaced);
     this.form.markAsPristine();
     this.form.markAsUntouched();

--- a/src/modules/commons/validator/existing-url-validation.ts
+++ b/src/modules/commons/validator/existing-url-validation.ts
@@ -60,11 +60,12 @@ export class SeedUrlValidator {
         }
       }
       const intersection = urls.filter(url => {
-        const similarUrlRegexp = createSimilarDomainRegExpString(url);
-        if (similarUrlRegexp === null) {
+        const similarUrlRegexpStr = createSimilarDomainRegExpString(url);
+        if (similarUrlRegexpStr === null) {
           return false;
         }
-        const similarUrlPredicate = (u) => (new RegExp(similarUrlRegexp).test(u));
+        const similarUrlRegexp = new RegExp(similarUrlRegexpStr);
+        const similarUrlPredicate = (u) => (similarUrlRegexp.test(u));
         return urlsWithinSameEntity.find(similarUrlPredicate);
       });
 

--- a/src/modules/commons/validator/patterns.spec.ts
+++ b/src/modules/commons/validator/patterns.spec.ts
@@ -105,12 +105,12 @@ describe('Regular expression patterns', () => {
       const expected = 'behave.properly';
       const actual = url.match(SIMILAR_URL)[1];
 
-      expect(expected).toBe(actual);
+      expect(actual).toBe(expected);
 
       const expected1 = 'not.behave.properly';
       const actual1 = url1.match(SIMILAR_URL)[1];
 
-      expect(expected1).toBe(actual1);
+      expect(actual1).toBe(expected1);
     }));
   });
 

--- a/src/modules/configurations/containers/logconfig/loglevel.component.spec.ts
+++ b/src/modules/configurations/containers/logconfig/loglevel.component.spec.ts
@@ -4,6 +4,7 @@ import {CommonsModule} from '../../../commons/commons.module';
 import {HttpClientTestingModule} from '@angular/common/http/testing';
 import {CoreTestingModule} from '../../../core/core.testing.module';
 import {SnackBarService} from '../../../core/services';
+import {RouterTestingModule} from '@angular/router/testing';
 
 describe('LoglevelComponent', () => {
   let component: LoglevelComponent;
@@ -13,6 +14,7 @@ describe('LoglevelComponent', () => {
     TestBed.configureTestingModule({
       imports: [
         CommonsModule,
+        RouterTestingModule,
         CoreTestingModule.forRoot(),
         HttpClientTestingModule
       ],

--- a/src/modules/configurations/containers/seed-configurations/seed-configurations.component.html
+++ b/src/modules/configurations/containers/seed-configurations/seed-configurations.component.html
@@ -7,14 +7,14 @@
 </button>
 
 <mat-progress-bar mode="indeterminate" *ngIf="loading$ | async"></mat-progress-bar>
-
-<app-base-list #baseList
+<app-seed-base-list #baseList
+               [dataSource]="dataSource"
                (action)="onAction($event)"
                (rowClick)="onSelectConfig($event)"
                (selectedChange)="onSelectedChange($event)"
                (selectAll)="onSelectAll()"
                [embedded]="entityRef">
-</app-base-list>
+</app-seed-base-list>
 
 <app-seed-details *ngIf="singleMode && configObject$ | async as configObject"
                   [configObject]="configObject"

--- a/src/modules/configurations/containers/seed-configurations/seed-configurations.component.ts
+++ b/src/modules/configurations/containers/seed-configurations/seed-configurations.component.ts
@@ -20,6 +20,7 @@ import {ReferrerError} from '../../../commons';
 import {ConfigurationsComponent} from '..';
 import {SeedConfigurationService} from '../../services/seed-configuration.service';
 import {LabelService} from '../../services/label.service';
+import {DataSource} from '@angular/cdk/table';
 
 @Component({
   selector: 'app-seed-configurations',
@@ -36,6 +37,7 @@ export class SeedConfigurationsComponent extends ConfigurationsComponent impleme
   @Output()
   invalidate: EventEmitter<void> = new EventEmitter();
 
+
   constructor(protected configurationsService: SeedConfigurationService,
               protected snackBarService: SnackBarService,
               protected errorService: ErrorService,
@@ -50,6 +52,10 @@ export class SeedConfigurationsComponent extends ConfigurationsComponent impleme
 
     this.kind = Kind.SEED;
     this.labelService.kind = this.kind;
+  }
+
+  get dataSource(): DataSource<ConfigObject> {
+    return this.configurationsService.getDataSource();
   }
 
   ngOnInit() {

--- a/src/modules/configurations/services/data/data.service.ts
+++ b/src/modules/configurations/services/data/data.service.ts
@@ -297,11 +297,11 @@ export class DataService implements DataSource<ConfigObject>, OnDestroy {
       : null;
   }
 
-  private incrementCount() {
+  protected incrementCount() {
     this.pageLength += 1;
   }
 
-  private decrementCount() {
+  protected decrementCount() {
     this.pageLength -= 1;
   }
 

--- a/src/modules/configurations/services/seed-configuration.service.ts
+++ b/src/modules/configurations/services/seed-configuration.service.ts
@@ -5,6 +5,7 @@ import {ErrorService} from '../../core/services';
 import {ConfigurationsService} from './configurations.service';
 import {SeedDataService} from './data';
 import {ConfigObject} from '../../commons/models';
+import {DataSource} from '@angular/cdk/table';
 
 @Injectable()
 export class SeedConfigurationService extends ConfigurationsService {
@@ -18,11 +19,19 @@ export class SeedConfigurationService extends ConfigurationsService {
     this.configObject$ = NEVER;
   }
 
+  getDataSource(): DataSource<ConfigObject> {
+    return this.dataService.dataSource;
+  }
+
   move(configObject: ConfigObject): Observable<number> {
     return this.dataService.move(configObject);
   }
 
   moveMultiple(configObjects: ConfigObject[]): Observable<number> {
     return this.dataService.moveMultiple(configObjects);
+  }
+
+  reload() {
+    this.dataService.reload();
   }
 }


### PR DESCRIPTION
Add seed-base-list component to list seeds in entity/seed view. 
The new list uses MatTableDataSource and adds functionality for:
 - Filter list by url
 - Sort list by url
 - Fetch all seeds for selected entity at once: 
      - Gives correct count of seeds in table
      - Validator can find duplicates without having to page through all available seeds in the list.