### PR TITLE
Remove client side filtering of queries for disabled fields

### DIFF
--- a/src/modules/commons/services/config.service.ts
+++ b/src/modules/commons/services/config.service.ts
@@ -144,7 +144,7 @@ export class ConfigService
           fieldMask.addPaths('crawlJob.crawlConfigRef');
           queryTemplate.crawlJob.crawlConfigRef = new ConfigRef({id: query.crawlConfigId, kind: Kind.CRAWLCONFIG});
         }
-        if (query.disabled) {
+        if (query.disabled !== null) {
           fieldMask.addPaths('crawlJob.disabled');
           queryTemplate.crawlJob.disabled = query.disabled;
         }
@@ -193,7 +193,7 @@ export class ConfigService
           fieldMask.addPaths('seed.jobRef');
           queryTemplate.seed.jobRefList = query.crawlJobIdList.map(id => new ConfigRef({id, kind: Kind.CRAWLJOB}));
         }
-        if (query.disabled) {
+        if (query.disabled !== null) {
           fieldMask.addPaths('seed.disabled');
           queryTemplate.seed.disabled = query.disabled;
         }

--- a/src/modules/config/directives/config-query.directive.ts
+++ b/src/modules/config/directives/config-query.directive.ts
@@ -19,24 +19,4 @@ export class ConfigQueryDirective extends QueryDirective<ConfigQuery, ConfigObje
               @Inject(BASE_LIST) private baseList: ConfigListComponent) {
     super(configService, baseList, new ListDataSource<ConfigObject>());
   }
-
-  protected onInit(): void {
-    this.query$.pipe(
-      switchMap(query => this.service.search(query).pipe(
-        filter(c => {
-          if (query.disabled !== null) {
-            switch (c.kind) {
-              case Kind.SEED:
-                return query.disabled ? c.seed?.disabled : !c.seed?.disabled;
-              case Kind.CRAWLJOB:
-                return query.disabled ? c.crawlJob?.disabled : !c.crawlJob?.disabled;
-            }
-          } else {
-            return true;
-          }
-        }),
-      )),
-      takeUntil(this.ngUnsubscribe)
-    ).subscribe(item => this.dataSource.add(item));
-  }
 }


### PR DESCRIPTION
Backend now supports filtering on default value fields not explicitly stored in database.