### PR TITLE
Explicitly use default branch name in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,7 +3,7 @@ name: Release
 on:
   push:
     branches:
-      - ${{ github.event.repository.default_branch }}
+      - master
     tags:
       - v*
 


### PR DESCRIPTION
Using a variable didn't seem to trigger workflow.