### PR TITLE
Jobexecution duration

### DIFF
--- a/src/modules/report/components/job-execution-preview/job-execution-preview.component.html
+++ b/src/modules/report/components/job-execution-preview/job-execution-preview.component.html
@@ -3,7 +3,7 @@
   <div fxFlex fxLayout="row wrap" fxLayoutGap="16px">
     <mat-card>
       <h2>Duration</h2>
-      <h1>{{getDuration(jobExecutionStatus.startTime, jobExecutionStatus.endTime)}}</h1>
+      <h1>{{getDuration(jobExecutionStatus)}}</h1>
     </mat-card>
 
     <mat-card *ngIf="jobExecutionStatus.urisCrawled">

--- a/src/modules/report/components/job-execution-preview/job-execution-preview.component.ts
+++ b/src/modules/report/components/job-execution-preview/job-execution-preview.component.ts
@@ -148,11 +148,14 @@ export class JobExecutionPreviewComponent implements OnChanges {
     }
   }
 
-  getDuration(startTime: string, endTime: string): string {
-    if (!endTime) {
-      endTime = new Date().toUTCString();
+  getDuration(jobExec: JobExecutionStatus): string {
+    let endTime = jobExec.endTime;
+    if (!jobExec.endTime) {
+      if (jobExec.state === JobExecutionState.RUNNING || JobExecutionState.CREATED) {
+        endTime = new Date().toISOString();
+      }
     }
-    return durationBetweenDates(startTime, endTime);
+    return durationBetweenDates(jobExec.startTime, endTime);
   }
 
   getExecMap(executionStateMap: Map<string, number>) {

--- a/src/shared/func/datetime/datetime.ts
+++ b/src/shared/func/datetime/datetime.ts
@@ -59,6 +59,9 @@ export function toTimestampProto(timestamp: string): any {
 }
 
 export function durationBetweenDates(startTime: string, endTime: string): string {
+  if (endTime === '') {
+    return 'N/A';
+  }
   const start = moment(startTime);
   const end = moment(endTime);
   return moment.duration(end.diff(start)).format('d[days]:hh[hours]:mm[min]:ss[s]', {trim: 'both'});


### PR DESCRIPTION
- Display N/A in cases where end timestamp is missing from jobexecution. 
- Check for correct execution state when displaying runtime for running jobs