### PR TITLE
ci: run test workflow on push

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -3,7 +3,7 @@
 name: Test
 
 on:
-  pull_request:
+  push:
 
 env:
   REGISTRY: ghcr.io


### PR DESCRIPTION
Without this change the test workflow is only run on pull requests. Which makes it annoying to test changes during development, as you would always need to create a pull request first.